### PR TITLE
feat: add setup skill and documentation

### DIFF
--- a/.claude/commands/setup-clawdboard.md
+++ b/.claude/commands/setup-clawdboard.md
@@ -1,0 +1,136 @@
+# Setup Clawdboard
+
+You are setting up Clawdboard for this user. Clawdboard is a macOS menu bar app that monitors Claude Code sessions. This skill handles everything: building the app, installing hooks, and configuring IDE integration.
+
+## Phase 1: Detect Current State
+
+Run these checks and report results as a compact summary:
+
+1. **Clawdboard app**: Check if `Clawdboard.app` exists in `~/Applications/` or `/Applications/`
+2. **Hooks installed**: Read `~/.claude/settings.json` and check if any hook commands contain "clawdboard"
+3. **Hook script**: Check if `~/.clawdboard/hooks/clawdboard-hook.py` exists
+4. **iTerm2**: Check if `/Applications/iTerm.app` exists
+5. **iTerm2 Python API**: Run `defaults read com.googlecode.iterm2 EnableAPIServer 2>/dev/null` (1 = enabled)
+6. **iTerm2 scripts**: Check if `~/.config/iterm2/AppSupport/Scripts/AutoLaunch/clawdboard.py` exists
+7. **VS Code**: Check if `/Applications/Visual Studio Code.app` exists
+8. **VS Code CLI**: Run `which code 2>/dev/null`
+9. **VS Code native tabs**: Read `~/Library/Application Support/Code/User/settings.json` and check for `"window.nativeTabs": true`
+10. **Swift toolchain**: Run `swift --version 2>/dev/null` to check if Swift is available for building
+11. **mise**: Run `which mise 2>/dev/null` to check if mise is available
+
+Present the results, then move to Phase 2.
+
+## Phase 2: Ask Which Pathway
+
+Based on what IDEs are available, ask the user which pathway to set up:
+
+- **Terminal + iTerm2** — enables "Focus in iTerm2" button (switches to exact terminal pane)
+- **VS Code Extension** — enables "Focus in VS Code" button + native macOS tabs for session management
+- **Both** — if both IDEs are available
+
+Only offer pathways for IDEs that are actually installed.
+
+## Phase 3: Backup Settings
+
+Before making ANY changes:
+
+1. If `~/.claude/settings.json` exists, copy it to `~/.claude/settings.json.backup.$(date +%Y%m%d%H%M%S)`
+2. If modifying VS Code settings, copy `~/Library/Application Support/Code/User/settings.json` to `~/Library/Application Support/Code/User/settings.json.backup.$(date +%Y%m%d%H%M%S)`
+
+Tell the user what was backed up.
+
+## Phase 4: Build & Install App
+
+If Clawdboard.app is not already installed:
+
+1. If `mise` is available, run `mise run setup` first to ensure tools are installed
+2. Run `./scripts/bundle.sh` from the repo root — this builds a release binary and creates `Clawdboard.app`
+3. Copy `Clawdboard.app` to `~/Applications/` (create the directory if needed): `cp -r Clawdboard.app ~/Applications/`
+4. Launch it: `open ~/Applications/Clawdboard.app`
+
+If already installed, skip this phase but still update the hook script (Phase 5 handles this).
+
+## Phase 5: Install Hooks & Scripts
+
+### Common Steps (both pathways)
+
+1. Create directories:
+   ```
+   mkdir -p ~/.clawdboard/hooks
+   mkdir -p ~/.clawdboard/sessions
+   ```
+
+2. Copy the hook script from this repo:
+   ```
+   cp Sources/ClawdboardLib/Resources/clawdboard-hook.py ~/.clawdboard/hooks/clawdboard-hook.py
+   chmod 755 ~/.clawdboard/hooks/clawdboard-hook.py
+   ```
+
+3. Merge hooks into `~/.claude/settings.json`. Read the existing file (or start with `{}`), then ensure the `hooks` key contains entries for ALL of these events:
+
+   **Standard events** (each gets a wildcard matcher):
+   `SessionStart`, `PreToolUse`, `PostToolUse`, `PermissionRequest`, `Stop`, `UserPromptSubmit`, `SessionEnd`, `SubagentStart`, `SubagentStop`
+
+   Each standard event entry looks like:
+   ```json
+   {
+     "matcher": "*",
+     "hooks": [{"type": "command", "command": "python3 ~/.clawdboard/hooks/clawdboard-hook.py", "timeout": 10}]
+   }
+   ```
+
+   **Notification events** (two separate matchers added to a `Notification` array):
+   ```json
+   {"matcher": "idle_prompt", "hooks": [{"type": "command", "command": "python3 ~/.clawdboard/hooks/clawdboard-hook.py idle_prompt", "timeout": 10}]}
+   ```
+   ```json
+   {"matcher": "permission_prompt", "hooks": [{"type": "command", "command": "python3 ~/.clawdboard/hooks/clawdboard-hook.py permission_prompt", "timeout": 10}]}
+   ```
+
+   **IMPORTANT**: Preserve any existing hooks that don't contain "clawdboard" in their command. Remove existing clawdboard hooks first (to avoid duplicates), then append new ones. When merging JSON, use `python3 -c` or `jq` if available. Do NOT use sed/awk for JSON manipulation.
+
+### iTerm2 Pathway
+
+4. Copy iTerm2 scripts:
+   ```
+   mkdir -p ~/.config/iterm2/AppSupport/Scripts/AutoLaunch
+   cp Sources/ClawdboardLib/Resources/iterm2-integration.py ~/.config/iterm2/AppSupport/Scripts/AutoLaunch/clawdboard.py
+   chmod 755 ~/.config/iterm2/AppSupport/Scripts/AutoLaunch/clawdboard.py
+   cp Sources/ClawdboardLib/Resources/iterm2-focus.py ~/.clawdboard/iterm2-focus.py
+   chmod 755 ~/.clawdboard/iterm2-focus.py
+   ```
+
+5. Check if iTerm2 Python API is enabled. If NOT:
+   - Tell the user: **iTerm2 → Settings → General → Magic → Enable Python API**
+   - This cannot be done programmatically
+
+6. If iTerm2 is running, suggest restarting it so the AutoLaunch script picks up.
+
+### VS Code Pathway
+
+4. Check if `code` CLI is in PATH. If NOT:
+   - Tell the user: **Cmd+Shift+P → "Shell Command: Install 'code' command in PATH"**
+
+5. Read `~/Library/Application Support/Code/User/settings.json`. If `"window.nativeTabs"` is not set to `true`:
+   - Add `"window.nativeTabs": true` (merge, don't overwrite)
+   - Tell user to restart VS Code for the change to take effect
+
+## Phase 6: Verify & Summarize
+
+Run verification checks:
+
+1. Clawdboard.app is installed and running
+2. `~/.clawdboard/hooks/clawdboard-hook.py` exists and is executable
+3. `~/.claude/settings.json` contains all expected hook events
+4. For iTerm2: scripts are in place
+5. For VS Code: `nativeTabs` is set
+
+Print a clear summary:
+- What was installed/configured
+- Any manual steps still needed (e.g., enable iTerm2 Python API, install `code` CLI, restart IDE)
+- Note that new Claude Code sessions will be tracked automatically; existing sessions need to be restarted
+
+## Notes
+
+- The hook command path uses `~` (not expanded): `python3 ~/.clawdboard/hooks/clawdboard-hook.py`
+- All new sessions after setup will be tracked. Existing running sessions won't appear until restarted.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,49 @@
-# TODO
+# Clawdboard
 
- ⚠️ THIS PROJECT IS UNDER CONSTRUCTION, CREATED WITH HEAVY AI ASSISTANCE, USE AT YOUR OWN RISK
+Native macOS menu bar app for monitoring Claude Code agent sessions in real time.
+
+> **Warning** This project is under active development, created with heavy AI assistance. Use at your own risk.
+
+## Get Started
+
+```bash
+git clone https://github.com/apoco-labs/clawdboard.git
+cd clawdboard
+```
+
+Then open Claude Code and run:
+
+```
+/setup-clawdboard
+```
+
+This builds the app, installs it, configures hooks, and sets up your IDE integration (iTerm2 or VS Code) — all in one go.
+
+See the **[Setup Guide](docs/SETUP.md)** for details on what gets configured and manual setup instructions.
+
+## Features
+
+- Real-time session monitoring via Claude Code hooks
+- Status indicators: working, waiting, needs approval, abandoned
+- Context window usage tracking (percentage)
+- Model and git branch display
+- "Focus in iTerm2" — switch to the exact terminal pane
+- "Focus in VS Code" — open the correct workspace window
+- Native macOS tabs support for VS Code
+- Remote host monitoring via SSH
+- Session auto-cleanup for stale/crashed sessions
+
+## Development
+
+Requires: Swift 6 toolchain, [mise](https://mise.jdx.dev/)
+
+```bash
+mise run setup     # Install tools and git hooks
+mise run build     # swift build
+mise run run       # swift run Clawdboard
+mise run test      # swift test
+mise run format    # Auto-fix formatting
+mise run lint      # Check formatting + lint
+```
+
+See [CLAUDE.md](CLAUDE.md) for architecture details and conventions.

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -1,0 +1,97 @@
+# Getting the Most Out of Clawdboard
+
+Clawdboard monitors your Claude Code sessions from the macOS menu bar. The easiest way to set everything up:
+
+```bash
+git clone https://github.com/apoco-labs/clawdboard.git
+cd clawdboard
+```
+
+Then in Claude Code:
+
+```
+/setup-clawdboard
+```
+
+This builds the app, installs hooks, and configures your IDE — all automatically. It will back up your settings before making changes.
+
+The rest of this document explains what gets configured and how to do it manually.
+
+---
+
+## How It Works
+
+Clawdboard uses Claude Code **hooks** to track session state. Each hook event (session start, tool use, stop, etc.) triggers a Python script that writes a JSON state file to `~/.clawdboard/sessions/`. The menu bar app watches that directory and displays live status.
+
+On top of that, there are two IDE-specific integrations that enable the "Focus" button — jumping from Clawdboard directly to the right window/pane.
+
+## Pathway 1: Terminal + iTerm2
+
+### What You Get
+
+- Real-time session status in the menu bar
+- Context window usage, model, and git branch
+- **"Focus in iTerm2"** — switches to the exact pane running that session, even in split panes
+
+### Manual Setup
+
+1. **Enable iTerm2 Python API**: iTerm2 → Settings → General → Magic → Enable Python API
+
+2. **Install integration scripts** (from the repo):
+   ```bash
+   mkdir -p ~/.config/iterm2/AppSupport/Scripts/AutoLaunch
+   cp Sources/ClawdboardLib/Resources/iterm2-integration.py \
+      ~/.config/iterm2/AppSupport/Scripts/AutoLaunch/clawdboard.py
+   cp Sources/ClawdboardLib/Resources/iterm2-focus.py \
+      ~/.clawdboard/iterm2-focus.py
+   chmod 755 ~/.config/iterm2/AppSupport/Scripts/AutoLaunch/clawdboard.py \
+             ~/.clawdboard/iterm2-focus.py
+   ```
+
+   Or install from Clawdboard's Settings: **iTerm2 Integration → Install**.
+
+3. **Restart iTerm2** so it picks up the AutoLaunch script.
+
+### How It Works
+
+The AutoLaunch script runs in the background inside iTerm2, polling `~/.clawdboard/sessions/` every 2 seconds. It matches Claude Code processes to iTerm2 panes by walking the process tree, then writes the pane UUID back into the session file. The "Focus" button uses AppleScript to select that pane.
+
+---
+
+## Pathway 2: VS Code + Native macOS Tabs
+
+### What You Get
+
+- Real-time session status in the menu bar
+- Context window usage, model, and git branch
+- **"Focus in VS Code"** — opens the correct workspace window
+- **Native macOS tabs** — manage multiple Claude Code windows as tabs in one window
+
+### Manual Setup
+
+1. **Install the `code` CLI**: In VS Code, **Cmd+Shift+P → "Shell Command: Install 'code' command in PATH"**
+   (For Cursor: `cursor`. For Insiders: `code-insiders`.)
+
+2. **Enable native macOS tabs**: Add to VS Code settings (`Cmd+Shift+P → Preferences: Open User Settings (JSON)`):
+   ```json
+   "window.nativeTabs": true
+   ```
+   Restart VS Code after changing this.
+
+3. **No additional hook setup needed** — the Claude Code VS Code extension automatically creates lock files that Clawdboard reads.
+
+### How It Works
+
+The Claude Code extension writes lock files to `~/.claude/ide/` with workspace folders and PID. Clawdboard matches each session's working directory to the most specific workspace folder. The "Focus" button runs `code <workspace-path>` to bring the correct window forward. Native macOS tabs let you merge all VS Code windows into one tabbed window (**Window → Merge All Windows**).
+
+---
+
+## Troubleshooting
+
+**Sessions not appearing**: Hooks load at session start — restart running Claude Code sessions. Check `~/.claude/settings.json` has entries containing "clawdboard".
+
+**"Focus in iTerm2" missing**: Check Python API is enabled (Settings → General → Magic). Restart iTerm2 after installing scripts.
+
+**"Focus in VS Code" missing**: Check `code --version` works in terminal. Make sure Claude Code is running inside VS Code, not a standalone terminal.
+
+**Native tabs not working**: Restart VS Code after setting `"window.nativeTabs": true`. Use **Window → Merge All Windows** to combine existing windows.


### PR DESCRIPTION
## Summary
- Add `/setup-clawdboard` slash command that automates full setup: builds the app, installs hooks, configures iTerm2 or VS Code integration, and backs up settings before making changes
- Add `docs/SETUP.md` with detailed guides for both pathways (Terminal + iTerm2, VS Code + native macOS tabs) including manual setup and troubleshooting
- Replace README placeholder with proper project README that leads with clone → `/setup-clawdboard`

## Test plan
- [ ] Run `/setup-clawdboard` in Claude Code from the repo directory
- [ ] Verify hooks appear in `~/.claude/settings.json`
- [ ] Verify settings backup is created before changes
- [ ] Test iTerm2 pathway: scripts installed, focus button works
- [ ] Test VS Code pathway: native tabs enabled, focus button works