### PR TITLE
feat: generate AI session titles via claude CLI

### DIFF
--- a/Sources/ClawdboardLib/Models.swift
+++ b/Sources/ClawdboardLib/Models.swift
@@ -234,7 +234,10 @@ public struct AgentSession: Identifiable, Codable, Equatable {
     /// iTerm2 session UUID, written back by the iTerm2 integration script
     public var iterm2SessionId: String?
 
-    /// The first user prompt, used as a session label
+    /// AI-generated session title (available after title generation completes)
+    public var title: String?
+
+    /// The first user prompt, used as a fallback label
     public var firstPrompt: String?
 
     enum CodingKeys: String, CodingKey {
@@ -254,6 +257,7 @@ public struct AgentSession: Identifiable, Codable, Equatable {
         case remoteHost = "remote_host"
         case githubRepo = "github_repo"
         case iterm2SessionId = "iterm2_session_id"
+        case title
         case firstPrompt = "first_prompt"
     }
 
@@ -274,6 +278,7 @@ public struct AgentSession: Identifiable, Codable, Equatable {
         remoteHost: String? = nil,
         githubRepo: String? = nil,
         iterm2SessionId: String? = nil,
+        title: String? = nil,
         firstPrompt: String? = nil
     ) {
         self.sessionId = sessionId
@@ -292,6 +297,7 @@ public struct AgentSession: Identifiable, Codable, Equatable {
         self.remoteHost = remoteHost
         self.githubRepo = githubRepo
         self.iterm2SessionId = iterm2SessionId
+        self.title = title
         self.firstPrompt = firstPrompt
     }
 

--- a/Sources/ClawdboardLib/Resources/clawdboard-hook.py
+++ b/Sources/ClawdboardLib/Resources/clawdboard-hook.py
@@ -296,6 +296,59 @@ def write_state(state_file: Path, state: JsonDict) -> None:
     tmp.rename(state_file)
 
 
+_TITLE_SCRIPT = """\
+import json, os, subprocess
+from pathlib import Path
+
+state_file = Path(os.environ["_CLAWDBOARD_STATE_FILE"])
+prompts = json.loads(os.environ["_CLAWDBOARD_PROMPTS"])
+
+prompt_text = "\\n".join(f"Message {i+1}: {p}" for i, p in enumerate(prompts))
+claude_prompt = (
+    "Given these user messages from a coding session, generate a short "
+    "descriptive title (3-6 words, no quotes, no period). "
+    "Just output the title, nothing else.\\n\\n"
+    + prompt_text
+)
+
+try:
+    result = subprocess.run(
+        ["claude", "-p", claude_prompt, "--output-format", "text"],
+        capture_output=True, text=True, timeout=30,
+    )
+    title = result.stdout.strip()[:80] if result.returncode == 0 else ""
+except Exception:
+    title = ""
+
+try:
+    state = json.loads(state_file.read_text())
+    if title:
+        state["title"] = title
+    state.pop("title_generating", None)
+    tmp = state_file.with_suffix(".tmp")
+    tmp.write_text(json.dumps(state, indent=2))
+    tmp.rename(state_file)
+except Exception:
+    pass
+"""
+
+
+def generate_title_async(state_file: Path, user_prompts: list[str]) -> None:
+    """Spawn a detached process to generate a session title via claude CLI."""
+    env = os.environ.copy()
+    env["_CLAWDBOARD_STATE_FILE"] = str(state_file)
+    env["_CLAWDBOARD_PROMPTS"] = json.dumps(user_prompts)
+
+    subprocess.Popen(
+        [sys.executable, "-c", _TITLE_SCRIPT],
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        env=env,
+        start_new_session=True,
+    )
+
+
 def merge_transcript_data(state: JsonDict, transcript_data: JsonDict) -> None:
     for key in TRANSCRIPT_KEYS:
         if key in transcript_data and transcript_data[key] is not None:
@@ -403,12 +456,32 @@ def handle_user_prompt_submit(
         state = make_base_state(session_id, cwd, project_name, now, claude_pid)
     state["status"] = "working"
     state["updated_at"] = now
-    # Capture the first user prompt as the session name
+    # Capture the first user prompt as a fallback label
     if prompt and not state.get("first_prompt"):
-        # Take first line, strip whitespace, truncate to 100 chars
         first_line = prompt.strip().split("\n")[0].strip()
         if first_line:
             state["first_prompt"] = first_line[:100]
+
+    # Track user message count and accumulate prompts for title generation
+    count = state.get("user_message_count", 0) + 1
+    state["user_message_count"] = count
+    prompts = state.get("user_prompts", [])
+    if len(prompts) < 3 and prompt:
+        first_line = prompt.strip().split("\n")[0].strip()[:200]
+        if first_line:
+            prompts.append(first_line)
+        state["user_prompts"] = prompts
+
+    # Generate title on message 1 (quick) and message 3 (refined)
+    # Message 3 always triggers even if message 1 generation is still running
+    should_generate = count in (1, 3) and prompts
+    if should_generate and (count == 3 or not state.get("title_generating")):
+        state["title_generating"] = True
+        merge_transcript_data(state, data)
+        write_state(state_file, state)
+        generate_title_async(state_file, prompts)
+        return
+
     merge_transcript_data(state, data)
     write_state(state_file, state)
 

--- a/Sources/ClawdboardLib/Views/AgentRow.swift
+++ b/Sources/ClawdboardLib/Views/AgentRow.swift
@@ -32,9 +32,9 @@ public struct AgentRow: View {
                 StatusDot(status: session.displayStatus)
 
                 VStack(alignment: .leading, spacing: 1) {
-                    Text(session.firstPrompt ?? session.projectName)
+                    Text(session.title ?? session.projectName)
                         .font(
-                            session.firstPrompt != nil
+                            session.title != nil
                                 ? .system(.body, weight: .medium)
                                 : .system(.body, design: .monospaced, weight: .medium)
                         )


### PR DESCRIPTION
## Summary

- After the 1st user message, spawns a background `claude -p` call to generate a short 3-6 word session title
- On the 3rd message, regenerates with richer context (all 3 prompts) for a better title
- Title displays in the menu bar UI, falling back to `projectName` while generating or on failure
- `firstPrompt` is retained in the model as internal data but no longer displayed

## Implementation

- **Hook script**: new `generate_title_async()` spawns a fully detached subprocess that calls `claude -p`, then atomically writes the title back to the session state JSON. Data is passed via environment variables to avoid injection issues with user prompt content
- **Swift model**: added `title: String?` to `AgentSession`
- **UI**: `AgentRow` now shows `title ?? projectName`

## Test plan

- [ ] Start a Claude Code session, send 1 message — title should appear after a few seconds
- [ ] Send 2 more messages — title should update with a refined version
- [ ] Verify hook returns immediately (no blocking)
- [ ] Test with `claude` CLI unavailable — should gracefully show `projectName`
- [ ] `swift build` passes
- [ ] `swift test` — all 19 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)