### PR TITLE
feat: configurable alert sound for approval prompts

### DIFF
--- a/Sources/ClawdboardLib/AlertSoundManager.swift
+++ b/Sources/ClawdboardLib/AlertSoundManager.swift
@@ -1,0 +1,62 @@
+import AVFoundation
+import Foundation
+
+/// Manages an optional alert sound that plays when any session transitions to "needs approval".
+public class AlertSoundManager {
+    public static let shared = AlertSoundManager()
+
+    private static let bookmarkKey = "alertSoundBookmark"
+    private var player: AVAudioPlayer?
+
+    private init() {}
+
+    /// The resolved URL from the stored security-scoped bookmark, or nil if not set.
+    public var soundFileURL: URL? {
+        guard let data = UserDefaults.standard.data(forKey: Self.bookmarkKey) else { return nil }
+        var isStale = false
+        guard
+            let url = try? URL(
+                resolvingBookmarkData: data, options: .withSecurityScope,
+                relativeTo: nil, bookmarkDataIsStale: &isStale)
+        else { return nil }
+        if isStale {
+            // Re-save a fresh bookmark if possible
+            if let fresh = try? url.bookmarkData(options: .withSecurityScope) {
+                UserDefaults.standard.set(fresh, forKey: Self.bookmarkKey)
+            }
+        }
+        return url
+    }
+
+    /// The display name of the configured sound file.
+    public var soundFileName: String? {
+        soundFileURL?.lastPathComponent
+    }
+
+    /// Store a new sound file URL as a security-scoped bookmark.
+    public func setSoundFile(_ url: URL) {
+        guard let data = try? url.bookmarkData(options: .withSecurityScope) else { return }
+        UserDefaults.standard.set(data, forKey: Self.bookmarkKey)
+    }
+
+    /// Remove the configured sound file.
+    public func clearSoundFile() {
+        UserDefaults.standard.removeObject(forKey: Self.bookmarkKey)
+        player?.stop()
+        player = nil
+    }
+
+    /// Play the configured alert sound. No-op if no sound is configured.
+    public func play() {
+        guard let url = soundFileURL else { return }
+        let accessed = url.startAccessingSecurityScopedResource()
+        defer { if accessed { url.stopAccessingSecurityScopedResource() } }
+
+        do {
+            player = try AVAudioPlayer(contentsOf: url)
+            player?.play()
+        } catch {
+            // Silently fail — sound is a nice-to-have
+        }
+    }
+}

--- a/Sources/ClawdboardLib/AppState.swift
+++ b/Sources/ClawdboardLib/AppState.swift
@@ -36,6 +36,9 @@ public class AppState {
     /// Local sessions from the local watcher
     private var localSessions: [AgentSession] = []
 
+    /// Previous display statuses keyed by session ID — used to detect transitions to needsApproval
+    private var previousStatuses: [String: AgentStatus] = [:]
+
     private static let remoteHostsKey = "remoteHosts"
 
     private let sessionsDir: URL = {
@@ -247,7 +250,25 @@ public class AppState {
             }
         }
 
+        // Detect any session that just transitioned to needsApproval
+        var shouldPlayAlert = false
+        for session in all {
+            let display = session.displayStatus
+            let previous = previousStatuses[session.sessionId]
+            if display == .needsApproval && previous != nil && previous != .needsApproval {
+                shouldPlayAlert = true
+            }
+            previousStatuses[session.sessionId] = display
+        }
+        // Clean up stale entries
+        let activeIds = Set(all.map(\.sessionId))
+        previousStatuses = previousStatuses.filter { activeIds.contains($0.key) }
+
         sessions = all
+
+        if shouldPlayAlert {
+            AlertSoundManager.shared.play()
+        }
     }
 
     // MARK: - Session Processing

--- a/Sources/ClawdboardLib/Views/SettingsView.swift
+++ b/Sources/ClawdboardLib/Views/SettingsView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import UniformTypeIdentifiers
 
 /// Settings form accessible via ⌘, or from the panel.
 public struct SettingsView: View {
@@ -8,6 +9,7 @@ public struct SettingsView: View {
     @State private var iterm2Installed = false
     @State private var isInstallingITerm2 = false
     @State private var sshConfigHosts: [SSHConfigHost] = []
+    @State private var alertSoundName: String? = AlertSoundManager.shared.soundFileName
     @AppStorage("useRedYellowMode") private var useRedYellowMode = true
     @AppStorage("usageRingThreshold") private var usageRingThreshold = 50
     @AppStorage("autoDeleteHours") private var autoDeleteHours: Double = 0.0
@@ -46,6 +48,40 @@ public struct SettingsView: View {
                         )
                         .font(.caption)
                         .foregroundStyle(.secondary)
+                    }
+                }
+            }
+
+            Section("Notifications") {
+                HStack {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("Approval alert sound")
+                        Text(
+                            alertSoundName ?? "None — plays when a session needs approval"
+                        )
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    }
+
+                    Spacer()
+
+                    if alertSoundName != nil {
+                        Button {
+                            AlertSoundManager.shared.play()
+                        } label: {
+                            Image(systemName: "speaker.wave.2")
+                        }
+                        .buttonStyle(.borderless)
+                        .help("Preview sound")
+
+                        Button("Clear", role: .destructive) {
+                            AlertSoundManager.shared.clearSoundFile()
+                            alertSoundName = nil
+                        }
+                    }
+
+                    Button("Choose...") {
+                        chooseAlertSound()
                     }
                 }
             }
@@ -270,6 +306,25 @@ public struct SettingsView: View {
     private func uninstallITerm2() {
         ITerm2Installer.uninstall()
         iterm2Installed = false
+    }
+
+    private func chooseAlertSound() {
+        let panel = NSOpenPanel()
+        panel.title = "Choose Alert Sound"
+        panel.allowedContentTypes = [
+            UTType.mp3,
+            UTType.wav,
+            UTType.aiff,
+            UTType(filenameExtension: "m4a") ?? UTType.audio,
+        ]
+        panel.allowsMultipleSelection = false
+        panel.canChooseDirectories = false
+
+        if panel.runModal() == .OK, let url = panel.url {
+            AlertSoundManager.shared.setSoundFile(url)
+            alertSoundName = AlertSoundManager.shared.soundFileName
+            AlertSoundManager.shared.play()
+        }
     }
 
     private func uninstallHooks() {

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -291,6 +291,7 @@ Shown when no sessions exist.
 | `chevron.right` / `chevron.down` | Section collapse toggle | 8pt system, `.semibold` |
 | `network` | Remote host indicator | `.caption2` |
 | `gearshape` | Settings menu | `.caption` |
+| `speaker.wave.2` | Preview alert sound | Settings |
 | `arrow.clockwise` | Refresh usage (footer) | `.caption` |
 | `checkmark.circle.fill` | Hooks installed (green) | Settings |
 | `xmark.circle` | No hooks (orange) | Settings |
@@ -326,6 +327,20 @@ Shown when no sessions exist.
 | StatusDot pulse | 1.0s | ease-in-out | Opacity 1.0↔0.4, repeats forever. Active for approval only. |
 | Row expand/collapse | 0.15s | ease-in-out | Bound to `isExpanded` state |
 | Group collapse/expand | 0.15s | ease-in-out | Bound to `collapsedGroups` state |
+
+---
+
+## Audio Alerts
+
+| Trigger | Behavior |
+|---------|----------|
+| Session transitions to **needs approval** | Plays user-configured sound file (MP3/WAV/AIFF/M4A) if set |
+
+- Configured in Settings → General → **Notifications** section
+- "Choose..." opens a native file picker; the selected file is stored as a security-scoped bookmark so it persists across app restarts
+- Preview button (`speaker.wave.2`) plays the sound inline
+- "Clear" removes the configured sound
+- Sound plays once per transition — a session already in approval state won't re-trigger on subsequent rebuilds
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds a user-configurable alert sound that plays when any session transitions to the "needs approval" state
- New **Notifications** section in Settings with Choose/Preview/Clear controls
- Supports MP3, WAV, AIFF, and M4A files; persisted as a security-scoped bookmark across restarts
- Sound triggers once per state transition — won't re-fire if session stays in approval

## Implementation

- **`AlertSoundManager`** — singleton managing file bookmark persistence (UserDefaults) and `AVAudioPlayer` playback
- **`AppState.rebuildSessions`** — tracks previous display statuses per session ID; detects transitions to `.needsApproval`
- **`SettingsView`** — `NSOpenPanel` file picker with UTType filtering, preview button, and clear action
- **`docs/DESIGN.md`** — new Audio Alerts section documenting the feature

## Test plan

- [ ] Open Settings → General, verify "Notifications" section appears with "Choose..." button
- [ ] Click "Choose...", pick an MP3 — sound plays as preview, filename shown in the label
- [ ] Click speaker icon to preview the sound again
- [ ] Click "Clear" — label resets to "None", preview button disappears
- [ ] Trigger a real needs-approval state (run Claude Code, hit a permission prompt) — sound plays
- [ ] Verify sound does NOT play when session stays in approval or transitions to other states
- [ ] Restart app — configured sound persists and still works