### PR TITLE
feat: add JetBrains IDE focus with terminal panel activation

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ See the **[Setup Guide](docs/SETUP.md)** for details on what gets configured and
 - Model and git branch display
 - "Focus in iTerm2" — switch to the exact terminal pane
 - "Focus in VS Code" — open the correct workspace window
+- "Focus in JetBrains" — open the project and activate the Terminal panel
 - Native macOS tabs support for VS Code
 - Remote host monitoring via SSH
 - Session auto-cleanup for stale/crashed sessions

--- a/Sources/ClawdboardLib/AppState.swift
+++ b/Sources/ClawdboardLib/AppState.swift
@@ -269,8 +269,7 @@ public class AppState {
             processSession(session, now: now)
         }
 
-        let processedRemote = remoteSessions.values.flatMap { $0 }.compactMap {
-            session -> AgentSession? in
+        let processedRemote = remoteSessions.values.flatMap { $0 }.compactMap { session -> AgentSession? in
             processSession(session, now: now)
         }
 
@@ -412,64 +411,142 @@ public class AppState {
         let focusScript = FileManager.default.homeDirectoryForCurrentUser
             .appendingPathComponent(".clawdboard/iterm2-focus.py")
         guard FileManager.default.fileExists(atPath: focusScript.path) else { return }
-        let task = Process()
-        task.executableURL = URL(fileURLWithPath: "/usr/bin/python3")
-        task.arguments = [focusScript.path, uuid]
-        task.standardOutput = FileHandle.nullDevice
-        task.standardError = FileHandle.nullDevice
-        DispatchQueue.global(qos: .userInitiated).async {
-            try? task.run()
-            task.waitUntilExit()
-        }
+        Self.runProcess("/usr/bin/python3", arguments: [focusScript.path, uuid])
     }
 
-    public func focusVSCodeSession(_ session: AgentSession) {
+    public func focusIDESession(_ session: AgentSession) {
         guard let lock = ideLockInfo(for: session) else { return }
 
         // Use workspace folder from lock file, fall back to session cwd.
         let folderPath = lock.workspaceFolders.first ?? session.cwd
         guard !folderPath.isEmpty else { return }
 
-        // If the folder contains a .code-workspace file, pass that instead so
-        // the `code` CLI focuses the existing workspace window rather than
-        // opening the folder as a new window.
-        let targetPath = Self.findCodeWorkspace(in: folderPath) ?? folderPath
-
-        // Derive CLI command from IDE name.
+        let family = Self.ideFamily(for: lock.ideName)
         let command = Self.cliCommand(for: lock.ideName)
 
-        let fm = FileManager.default
-        let candidates = [
-            "/usr/local/bin/\(command)",
-            "/opt/homebrew/bin/\(command)",
-        ]
+        // For VS Code family, prefer .code-workspace file if present.
+        let targetPath =
+            family == .vscode
+            ? (Self.findCodeWorkspace(in: folderPath) ?? folderPath)
+            : folderPath
 
-        guard let executablePath = candidates.first(where: { fm.isExecutableFile(atPath: $0) })
-        else {
-            DispatchQueue.main.async {
-                Self.showVSCodeCLIAlert(command: command)
+        if let executablePath = Self.findIDEExecutable(command: command, family: family) {
+            Self.runProcess(executablePath, arguments: [targetPath])
+            if family == .jetbrains {
+                Self.activateJetBrainsTerminal()
             }
             return
         }
 
-        let task = Process()
-        task.executableURL = URL(fileURLWithPath: executablePath)
-        task.arguments = [targetPath]
-        task.standardOutput = FileHandle.nullDevice
-        task.standardError = FileHandle.nullDevice
+        // JetBrains fallback: use macOS `open -a` with the IDE's display name.
+        if family == .jetbrains {
+            Self.runProcess("/usr/bin/open", arguments: ["-a", lock.ideName, targetPath]) { status in
+                if status == 0 {
+                    Self.activateJetBrainsTerminal()
+                } else {
+                    DispatchQueue.main.async {
+                        Self.showIDECLIAlert(command: command, family: .jetbrains)
+                    }
+                }
+            }
+            return
+        }
 
-        DispatchQueue.global(qos: .userInitiated).async {
-            try? task.run()
-            task.waitUntilExit()
+        DispatchQueue.main.async {
+            Self.showIDECLIAlert(command: command, family: family)
         }
     }
 
-    /// Map IDE name from the lock file to the corresponding CLI command.
+    // MARK: - Process Helpers
+
+    /// Run an executable asynchronously with stdout/stderr silenced.
+    @discardableResult
+    private static func runProcess(
+        _ executable: String,
+        arguments: [String],
+        completion: ((Int32) -> Void)? = nil
+    ) -> Process {
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: executable)
+        task.arguments = arguments
+        task.standardOutput = FileHandle.nullDevice
+        task.standardError = FileHandle.nullDevice
+        DispatchQueue.global(qos: .userInitiated).async {
+            try? task.run()
+            task.waitUntilExit()
+            completion?(task.terminationStatus)
+        }
+        return task
+    }
+
+    /// Send ⌥F12 to the frontmost JetBrains IDE to activate the Terminal tool window.
+    private static func activateJetBrainsTerminal() {
+        DispatchQueue.global(qos: .userInitiated).asyncAfter(deadline: .now() + 0.5) {
+            let script = """
+                tell application "System Events"
+                    key code 111 using {option down}
+                end tell
+                """
+            Self.runProcess("/usr/bin/osascript", arguments: ["-e", script])
+        }
+    }
+
+    /// Search standard paths for a CLI executable, returning the first match.
+    private static func findIDEExecutable(command: String, family: IDEFamily) -> String? {
+        let fm = FileManager.default
+        var candidates = [
+            "/usr/local/bin/\(command)",
+            "/opt/homebrew/bin/\(command)",
+        ]
+        if family == .jetbrains {
+            let home = fm.homeDirectoryForCurrentUser.path
+            candidates.insert(
+                "\(home)/Library/Application Support/JetBrains/Toolbox/scripts/\(command)", at: 0)
+        }
+        return candidates.first(where: { fm.isExecutableFile(atPath: $0) })
+    }
+
+    // MARK: - IDE Family
+
+    private enum IDEFamily {
+        case vscode, jetbrains, unknown
+    }
+
+    private struct IDEDefinition {
+        let keyword: String
+        let family: IDEFamily
+        let command: String
+    }
+
+    /// Single source of truth for keyword → (family, CLI command).
+    /// Order matters — "insiders" must precede "code".
+    private static let ideDefinitions: [IDEDefinition] = [
+        // VS Code family
+        .init(keyword: "insiders", family: .vscode, command: "code-insiders"),
+        .init(keyword: "cursor", family: .vscode, command: "cursor"),
+        .init(keyword: "code", family: .vscode, command: "code"),
+        // JetBrains family
+        .init(keyword: "webstorm", family: .jetbrains, command: "webstorm"),
+        .init(keyword: "pycharm", family: .jetbrains, command: "pycharm"),
+        .init(keyword: "intellij", family: .jetbrains, command: "idea"),
+        .init(keyword: "goland", family: .jetbrains, command: "goland"),
+        .init(keyword: "rubymine", family: .jetbrains, command: "rubymine"),
+        .init(keyword: "rider", family: .jetbrains, command: "rider"),
+        .init(keyword: "clion", family: .jetbrains, command: "clion"),
+        .init(keyword: "phpstorm", family: .jetbrains, command: "phpstorm"),
+        .init(keyword: "datagrip", family: .jetbrains, command: "datagrip"),
+        .init(keyword: "rustrover", family: .jetbrains, command: "rustrover"),
+        .init(keyword: "aqua", family: .jetbrains, command: "aqua"),
+    ]
+
+    private static func ideFamily(for ideName: String) -> IDEFamily {
+        let lower = ideName.lowercased()
+        return ideDefinitions.first(where: { lower.contains($0.keyword) })?.family ?? .unknown
+    }
+
     private static func cliCommand(for ideName: String) -> String {
         let lower = ideName.lowercased()
-        if lower.contains("insiders") { return "code-insiders" }
-        if lower.contains("cursor") { return "cursor" }
-        return "code"
+        return ideDefinitions.first(where: { lower.contains($0.keyword) })?.command ?? "code"
     }
 
     /// Look for a single `.code-workspace` file in the given directory.
@@ -485,12 +562,21 @@ public class AppState {
         return workspaceFiles.count == 1 ? workspaceFiles[0].path : nil
     }
 
-    private static func showVSCodeCLIAlert(command: String) {
+    private static func showIDECLIAlert(command: String, family: IDEFamily) {
         let alert = NSAlert()
         alert.messageText = "'\(command)' command not found"
-        alert.informativeText =
-            "Install it from VS Code: open the Command Palette (Cmd+Shift+P) "
-            + "and run \"Shell Command: Install '\(command)' command in PATH\"."
+        switch family {
+        case .vscode:
+            alert.informativeText =
+                "Install it from VS Code: open the Command Palette (Cmd+Shift+P) "
+                + "and run \"Shell Command: Install '\(command)' command in PATH\"."
+        case .jetbrains:
+            alert.informativeText =
+                "Install it via JetBrains Toolbox (Settings > Tools > Shell Scripts) "
+                + "or from the IDE: Tools > Create Command-line Launcher."
+        case .unknown:
+            alert.informativeText = "Could not find the '\(command)' CLI tool on your PATH."
+        }
         alert.alertStyle = .warning
         alert.addButton(withTitle: "OK")
         alert.runModal()

--- a/Sources/ClawdboardLib/Models.swift
+++ b/Sources/ClawdboardLib/Models.swift
@@ -388,7 +388,8 @@ public struct AgentSession: Identifiable, Codable, Equatable {
     /// or the "Open a pull request" page if not.
     public var compareUrl: String? {
         guard let repo = githubRepo, let branch = gitBranch else { return nil }
-        let encoded = branch.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed)
+        let encoded =
+            branch.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed)
             ?? branch
         return "https://github.com/\(repo)/compare/\(encoded)?expand=1"
     }

--- a/Sources/ClawdboardLib/Views/AgentRow.swift
+++ b/Sources/ClawdboardLib/Views/AgentRow.swift
@@ -7,7 +7,8 @@ public struct AgentRow: View {
     public let isExpanded: Bool
     public let onToggle: () -> Void
     public var onFocusiTerm2: (() -> Void)?
-    public var onFocusVSCode: (() -> Void)?
+    public var onFocusIDE: (() -> Void)?
+    public var ideName: String?
     public var onDelete: (() -> Void)?
 
     public init(
@@ -15,14 +16,16 @@ public struct AgentRow: View {
         isExpanded: Bool,
         onToggle: @escaping () -> Void,
         onFocusiTerm2: (() -> Void)? = nil,
-        onFocusVSCode: (() -> Void)? = nil,
+        onFocusIDE: (() -> Void)? = nil,
+        ideName: String? = nil,
         onDelete: (() -> Void)? = nil
     ) {
         self.session = session
         self.isExpanded = isExpanded
         self.onToggle = onToggle
         self.onFocusiTerm2 = onFocusiTerm2
-        self.onFocusVSCode = onFocusVSCode
+        self.onFocusIDE = onFocusIDE
+        self.ideName = ideName
         self.onDelete = onDelete
     }
 
@@ -120,8 +123,8 @@ public struct AgentRow: View {
                         .help("Focus in iTerm2")
                     }
 
-                    if let onFocusVSCode = onFocusVSCode {
-                        Button(action: onFocusVSCode) {
+                    if let onFocusIDE = onFocusIDE {
+                        Button(action: onFocusIDE) {
                             Image(systemName: "macwindow")
                                 .font(.body)
                                 .foregroundStyle(.secondary)
@@ -136,7 +139,7 @@ public struct AgentRow: View {
                                 NSCursor.pop()
                             }
                         }
-                        .help("Focus in VS Code")
+                        .help("Focus in \(ideName ?? "IDE")")
                     }
 
                 }

--- a/Sources/ClawdboardLib/Views/SessionsTab.swift
+++ b/Sources/ClawdboardLib/Views/SessionsTab.swift
@@ -57,6 +57,7 @@ public struct SessionsTab: View {
 
                     if !isCollapsed {
                         ForEach(group.sessions) { session in
+                            let lockInfo = appState.ideLockInfo(for: session)
                             AgentRow(
                                 session: session,
                                 isExpanded: appState.expandedSessionId == session.id,
@@ -66,10 +67,11 @@ public struct SessionsTab: View {
                                 onFocusiTerm2: session.iterm2SessionId != nil
                                     ? { appState.focusITerm2Session(session) }
                                     : nil,
-                                onFocusVSCode: session.iterm2SessionId == nil
-                                    && appState.ideLockInfo(for: session) != nil
-                                    ? { appState.focusVSCodeSession(session) }
+                                onFocusIDE: session.iterm2SessionId == nil
+                                    && lockInfo != nil
+                                    ? { appState.focusIDESession(session) }
                                     : nil,
+                                ideName: lockInfo?.ideName,
                                 onDelete: { appState.deleteSession(session.id) }
                             )
                         }

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -186,7 +186,7 @@ Single session row with expand/collapse.
 
 **Action buttons** (right side, HStack spacing 0):
 - Focus iTerm2: `apple.terminal` at `.body`, `.secondary`
-- Focus VS Code: `macwindow` at `.body`, `.secondary`
+- Focus IDE: `macwindow` at `.body`, `.secondary`, tooltip reads "Focus in {ideName}" (e.g. "Focus in WebStorm")
 - All buttons: 28×28pt hit target, `.plain` style, pointing hand cursor on hover
 
 **Context percentage**: `.caption2.monospacedDigit()`, 32pt wide trailing-aligned. Color follows the usage gauge color scale when elevated, otherwise `.secondary`. Shows "—" in `.tertiary` if not hook-tracked.
@@ -297,7 +297,7 @@ Shown when no sessions exist.
 |------|-----|------------|
 | `apple.terminal` | Empty state, menu bar idle | `.title2` |
 | `apple.terminal` | Focus iTerm2 | `.body` |
-| `macwindow` | Focus VS Code / IDE | `.body` |
+| `macwindow` | Focus IDE (VS Code, JetBrains, etc.) | `.body` |
 | `arrow.triangle.pull` | PR / branch link (metadata line) | `.caption2` |
 | `trash` | Delete session (expanded detail) | `.caption` |
 | `chevron.right` / `chevron.down` | Section collapse toggle | 8pt system, `.semibold` |


### PR DESCRIPTION
## Summary
- Generalize VS Code focus to support all JetBrains IDEs (WebStorm, IntelliJ, PyCharm, etc.)
- After focusing a JetBrains project, send ⌥F12 via AppleScript to activate the Terminal tool window
- Rename `focusVSCode` → `focusIDE` throughout; tooltip now shows the actual IDE name (e.g. "Focus in WebStorm")

## Known limitation
JetBrains does not expose terminal tab identifiers, so the Terminal panel opens but the correct tab among multiple tabs cannot be auto-selected without a JetBrains plugin.

## Test plan
- [ ] Focus a JetBrains session → IDE comes to foreground with Terminal panel visible
- [ ] Focus a VS Code session → behavior unchanged
- [ ] Tooltip reads "Focus in {IDE name}" for both families
- [ ] `mise run build` and `mise run lint` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)