### PR TITLE
feat: activity sparkline with approval markers

### DIFF
--- a/Sources/ClawdboardLib/Models.swift
+++ b/Sources/ClawdboardLib/Models.swift
@@ -197,6 +197,14 @@ public struct Subagent: Codable, Equatable, Identifiable {
     }
 }
 
+// MARK: - Context Snapshot
+
+/// A timestamped context usage snapshot for sparkline rendering.
+public struct ContextSnapshot: Codable, Equatable {
+    public let t: Date
+    public let pct: Double
+}
+
 // MARK: - Agent Session
 
 /// Represents a Claude Code agent session.
@@ -246,6 +254,12 @@ public struct AgentSession: Identifiable, Codable, Equatable {
     /// Lines deleted relative to default branch (from git diff --shortstat)
     public var deletions: Int?
 
+    /// Timestamped context usage snapshots for sparkline display (last ~100 entries)
+    public var contextSnapshots: [ContextSnapshot]?
+
+    /// Timestamps when approval was requested (for sparkline markers)
+    public var approvalTimestamps: [Date]?
+
     enum CodingKeys: String, CodingKey {
         case sessionId = "session_id"
         case cwd
@@ -267,6 +281,8 @@ public struct AgentSession: Identifiable, Codable, Equatable {
         case firstPrompt = "first_prompt"
         case additions
         case deletions
+        case contextSnapshots = "context_snapshots"
+        case approvalTimestamps = "approval_timestamps"
     }
 
     public init(
@@ -289,7 +305,9 @@ public struct AgentSession: Identifiable, Codable, Equatable {
         title: String? = nil,
         firstPrompt: String? = nil,
         additions: Int? = nil,
-        deletions: Int? = nil
+        deletions: Int? = nil,
+        contextSnapshots: [ContextSnapshot]? = nil,
+        approvalTimestamps: [Date]? = nil
     ) {
         self.sessionId = sessionId
         self.cwd = cwd
@@ -311,6 +329,8 @@ public struct AgentSession: Identifiable, Codable, Equatable {
         self.firstPrompt = firstPrompt
         self.additions = additions
         self.deletions = deletions
+        self.contextSnapshots = contextSnapshots
+        self.approvalTimestamps = approvalTimestamps
     }
 
     /// Display title: AI-generated slug title, or a placeholder while generating

--- a/Sources/ClawdboardLib/Resources/clawdboard-hook.py
+++ b/Sources/ClawdboardLib/Resources/clawdboard-hook.py
@@ -395,6 +395,17 @@ def merge_transcript_data(state: JsonDict, transcript_data: JsonDict) -> None:
             state[key] = val
 
 
+MAX_CONTEXT_SNAPSHOTS = 100
+
+
+def append_context_snapshot(state: JsonDict, pct: float, timestamp: str) -> None:
+    snapshots = state.get("context_snapshots", [])
+    snapshots.append({"t": timestamp, "pct": pct})
+    if len(snapshots) > MAX_CONTEXT_SNAPSHOTS:
+        snapshots = snapshots[-MAX_CONTEXT_SNAPSHOTS:]
+    state["context_snapshots"] = snapshots
+
+
 def make_base_state(
     session_id: str, cwd: str, project_name: str, now: str, claude_pid: int
 ) -> JsonDict:
@@ -442,6 +453,8 @@ def handle_session_start(
         "pid": claude_pid,
         "is_hook_tracked": True,
     }
+    if data.get("context_pct") is not None:
+        append_context_snapshot(state, data["context_pct"], now)
     write_state(state_file, state)
 
 
@@ -466,6 +479,8 @@ def handle_post_tool_use(
     # Then read transcript data and write again with full info
     data = read_transcript_data(transcript_path, state_file)
     merge_transcript_data(state, data)
+    if data.get("context_pct") is not None:
+        append_context_snapshot(state, data["context_pct"], now)
     write_state(state_file, state)
 
 
@@ -477,6 +492,8 @@ def handle_stop(state_file: Path, transcript_path: str, now: str) -> None:
     state["status"] = "pending_waiting"
     state["updated_at"] = now
     merge_transcript_data(state, data)
+    if data.get("context_pct") is not None:
+        append_context_snapshot(state, data["context_pct"], now)
     write_state(state_file, state)
 
 
@@ -520,11 +537,15 @@ def handle_user_prompt_submit(
         if not state.get("title"):
             state["title"] = random.choice(TITLE_PLACEHOLDERS)
         merge_transcript_data(state, data)
+        if data.get("context_pct") is not None:
+            append_context_snapshot(state, data["context_pct"], now)
         write_state(state_file, state)
         generate_title_async(state_file, prompts)
         return
 
     merge_transcript_data(state, data)
+    if data.get("context_pct") is not None:
+        append_context_snapshot(state, data["context_pct"], now)
     write_state(state_file, state)
 
 
@@ -544,6 +565,9 @@ def handle_notification(state_file: Path, notification_subtype: str, now: str) -
         return
     if notification_subtype == "permission_prompt":
         state["status"] = "needs_approval"
+        approvals = state.get("approval_timestamps", [])
+        approvals.append(now)
+        state["approval_timestamps"] = approvals
     else:
         # idle_prompt is async and can arrive after UserPromptSubmit has
         # already set the session back to "working". Never clobber working.
@@ -561,6 +585,9 @@ def handle_permission_request(state_file: Path, now: str) -> None:
     if state is None:
         return
     state["status"] = "needs_approval"
+    approvals = state.get("approval_timestamps", [])
+    approvals.append(now)
+    state["approval_timestamps"] = approvals
     state["updated_at"] = now
     write_state(state_file, state)
 

--- a/Sources/ClawdboardLib/Views/AgentRow.swift
+++ b/Sources/ClawdboardLib/Views/AgentRow.swift
@@ -38,69 +38,81 @@ public struct AgentRow: View {
         VStack(alignment: .leading, spacing: 0) {
             // Main row
             HStack(spacing: 8) {
-                StatusDot(status: session.displayStatus)
+                // Tappable content area (opens/focuses session)
+                HStack(spacing: 8) {
+                    StatusDot(status: session.displayStatus)
 
-                VStack(alignment: .leading, spacing: 1) {
-                    Text(session.displayTitle)
-                        .font(.system(.body, weight: .medium))
-                        .lineLimit(1)
+                    VStack(alignment: .leading, spacing: 1) {
+                        Text(session.displayTitle)
+                            .font(.system(.body, weight: .medium))
+                            .lineLimit(1)
 
-                    HStack(spacing: 4) {
-                        if let host = session.remoteHost {
-                            Image(systemName: "network")
-                                .font(.caption2)
-                            Text(host)
-                            Text("·")
-                        }
-                        Text(session.displayStatus.displayLabel)
-                        if session.isHookTracked {
-                            if let branch = session.gitBranch {
+                        HStack(spacing: 4) {
+                            if let host = session.remoteHost {
+                                Image(systemName: "network")
+                                    .font(.caption2)
+                                Text(host)
                                 Text("·")
-                                if let compareUrl = session.compareUrl,
-                                    let url = URL(string: compareUrl)
-                                {
-                                    Link(destination: url) {
-                                        HStack(spacing: 2) {
-                                            Image(systemName: "arrow.triangle.pull")
-                                                .font(.caption2)
-                                            Text(branch)
-                                                .lineLimit(1)
-                                                .truncationMode(.middle)
+                            }
+                            Text(session.displayStatus.displayLabel)
+                            if session.isHookTracked {
+                                if let branch = session.gitBranch {
+                                    Text("·")
+                                    if let compareUrl = session.compareUrl,
+                                        let url = URL(string: compareUrl)
+                                    {
+                                        Link(destination: url) {
+                                            HStack(spacing: 2) {
+                                                Image(systemName: "arrow.triangle.pull")
+                                                    .font(.caption2)
+                                                Text(branch)
+                                                    .lineLimit(1)
+                                                    .truncationMode(.middle)
+                                            }
                                         }
-                                    }
-                                    .layoutPriority(-1)
-                                    .pointingHandCursor()
-                                } else {
-                                    Text(branch)
-                                        .lineLimit(1)
-                                        .truncationMode(.middle)
                                         .layoutPriority(-1)
+                                        .pointingHandCursor()
+                                    } else {
+                                        Text(branch)
+                                            .lineLimit(1)
+                                            .truncationMode(.middle)
+                                            .layoutPriority(-1)
+                                    }
+                                }
+                                if let diffStats = session.formattedDiffStats {
+                                    Text("·")
+                                    DiffStatsLabel(stats: diffStats)
                                 }
                             }
-                            if let diffStats = session.formattedDiffStats {
+                            if session.activeSubagentCount > 0 {
                                 Text("·")
-                                DiffStatsLabel(stats: diffStats)
+                                Text(
+                                    "\(session.activeSubagentCount) subagent\(session.activeSubagentCount == 1 ? "" : "s")"
+                                )
                             }
                         }
-                        if session.displayStatus == .abandoned,
-                            let updatedAt = session.updatedAt
-                        {
-                            Text("·")
-                            Text(session.idleSince(updatedAt))
-                        }
-                        if session.activeSubagentCount > 0 {
-                            Text("·")
-                            Text(
-                                "\(session.activeSubagentCount) subagent\(session.activeSubagentCount == 1 ? "" : "s")"
-                            )
-                        }
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
                     }
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                    .lineLimit(1)
-                }
 
-                Spacer()
+                    Spacer()
+
+                    HStack(spacing: 4) {
+                        SparklineView(
+                            snapshots: session.contextSnapshots ?? [],
+                            approvalTimestamps: session.approvalTimestamps ?? []
+                        )
+                        Text(session.formattedContext)
+                            .font(.caption2.monospacedDigit())
+                            .foregroundStyle(.secondary)
+                            .frame(width: 30, alignment: .trailing)
+                    }
+                    .fixedSize()
+                }
+                .contentShape(Rectangle())
+                .pointingHandCursor()
+                .onTapGesture { onActivate() }
 
                 Button(action: onToggle) {
                     Image(
@@ -116,9 +128,6 @@ public struct AgentRow: View {
                 .help(isExpanded ? "Collapse" : "Expand")
 
             }
-            .contentShape(Rectangle())
-            .pointingHandCursor()
-            .onTapGesture { onActivate() }
             .contextMenu {
                 if let onFocusiTerm2 = onFocusiTerm2 {
                     Button {
@@ -189,6 +198,11 @@ public struct AgentRow: View {
                         .font(.caption)
                         .foregroundStyle(.secondary)
                         .frame(width: 60, alignment: .trailing)
+                    SparklineView(
+                        snapshots: session.contextSnapshots ?? [],
+                        approvalTimestamps: session.approvalTimestamps ?? []
+                    )
+                    .frame(width: 120, height: 20)
                     ContextBar(percentage: pct)
                     Text(session.formattedContext)
                         .font(.caption2.monospacedDigit())

--- a/Sources/ClawdboardLib/Views/Components.swift
+++ b/Sources/ClawdboardLib/Views/Components.swift
@@ -88,6 +88,116 @@ public struct ContextBar: View {
     }
 }
 
+// MARK: - Sparkline View
+
+/// Miniature activity chart showing context usage rate over a 30-minute window.
+/// Plots context_pct deltas per minute bucket — peaks = active generation, flat = idle.
+public struct SparklineView: View {
+    public let snapshots: [ContextSnapshot]
+    public var approvalTimestamps: [Date] = []
+
+    private static let windowMinutes = 30
+    private static let bucketCount = 30  // one bucket per minute
+
+    public init(snapshots: [ContextSnapshot], approvalTimestamps: [Date] = []) {
+        self.snapshots = snapshots
+        self.approvalTimestamps = approvalTimestamps
+    }
+
+    public var body: some View {
+        Canvas { context, size in
+            let windowStart = Date().addingTimeInterval(
+                -Double(Self.windowMinutes * 60))
+            let windowDuration = Double(Self.windowMinutes * 60)
+
+            let buckets = activityBuckets
+            guard buckets.count >= 2 else {
+                // Empty baseline
+                var baseline = Path()
+                baseline.move(to: CGPoint(x: 0, y: size.height - 0.5))
+                baseline.addLine(to: CGPoint(x: size.width, y: size.height - 0.5))
+                context.stroke(baseline, with: .color(.gray.opacity(0.2)), lineWidth: 1)
+                return
+            }
+
+            let maxVal = max(buckets.max() ?? 1, 0.1)  // avoid division by zero
+
+            let points: [CGPoint] = buckets.enumerated().map { index, value in
+                let x = size.width * CGFloat(index) / CGFloat(buckets.count - 1)
+                let y = size.height * (1 - CGFloat(value / maxVal))
+                return CGPoint(x: x, y: y)
+            }
+
+            var linePath = Path()
+            linePath.move(to: points[0])
+            for point in points.dropFirst() {
+                linePath.addLine(to: point)
+            }
+            context.stroke(linePath, with: .color(strokeColor), lineWidth: 1)
+
+            // Fill under the line
+            var fillPath = linePath
+            fillPath.addLine(to: CGPoint(x: points.last!.x, y: size.height))
+            fillPath.addLine(to: CGPoint(x: points.first!.x, y: size.height))
+            fillPath.closeSubpath()
+            context.fill(fillPath, with: .color(strokeColor.opacity(0.15)))
+
+            // Red dots for approval events within the window
+            let dotRadius: CGFloat = 1.0
+            for timestamp in approvalTimestamps {
+                guard timestamp >= windowStart else { continue }
+                let xPct = timestamp.timeIntervalSince(windowStart) / windowDuration
+                let x = size.width * CGFloat(xPct)
+                // Place dot on the line by interpolating the bucket value
+                let bucketIndex = xPct * Double(Self.bucketCount - 1)
+                let lowerIdx = min(Int(bucketIndex), Self.bucketCount - 2)
+                let frac = bucketIndex - Double(lowerIdx)
+                let value = buckets[lowerIdx] * (1 - frac) + buckets[lowerIdx + 1] * frac
+                let y = size.height * (1 - CGFloat(value / maxVal))
+                let dot = CGRect(
+                    x: x - dotRadius, y: y - dotRadius,
+                    width: dotRadius * 2, height: dotRadius * 2)
+                context.fill(Path(ellipseIn: dot), with: .color(.red))
+            }
+        }
+        .frame(width: 80, height: 16)
+    }
+
+    /// Compute activity (context_pct delta) per minute bucket over the last 30 minutes.
+    private var activityBuckets: [Double] {
+        guard snapshots.count >= 2 else { return [] }
+
+        let now = Date()
+        let windowStart = now.addingTimeInterval(
+            -Double(Self.windowMinutes * 60))
+        let bucketDuration = Double(Self.windowMinutes * 60) / Double(Self.bucketCount)
+
+        // Filter to last 30 minutes
+        let recent = snapshots.filter { $0.t >= windowStart }
+        guard recent.count >= 2 else { return [] }
+
+        // For each bucket, sum the positive context_pct deltas between consecutive snapshots
+        var buckets = [Double](repeating: 0, count: Self.bucketCount)
+
+        for i in 1..<recent.count {
+            let delta = max(recent[i].pct - recent[i - 1].pct, 0)  // only positive deltas (activity)
+            let bucketIndex = Int(recent[i].t.timeIntervalSince(windowStart) / bucketDuration)
+            let clampedIndex = min(max(bucketIndex, 0), Self.bucketCount - 1)
+            buckets[clampedIndex] += delta
+        }
+
+        return buckets
+    }
+
+    /// Color based on the most recent snapshot value, matching ContextBar thresholds.
+    private var strokeColor: Color {
+        guard let last = snapshots.last else { return .secondary }
+        if last.pct >= 90 { return .red }
+        if last.pct >= 70 { return .orange }
+        return .secondary
+    }
+}
+
 // MARK: - Usage Limits View
 
 /// Compact usage limits display showing both 5-hour and 7-day windows

--- a/Tests/ClawdboardTests/ModelsTests.swift
+++ b/Tests/ClawdboardTests/ModelsTests.swift
@@ -152,4 +152,62 @@ struct ModelsTests {
         let noStart = AgentSession(sessionId: "3", cwd: "/c", projectName: "c", isHookTracked: false)
         #expect(noStart.elapsedTime == "—")
     }
+
+    // MARK: - ContextSnapshot
+
+    @Test("ContextSnapshot decodes from JSON with short keys")
+    func contextSnapshotDecodes() throws {
+        let json = """
+            {"t": "2026-03-22T10:30:05Z", "pct": 42.5}
+            """
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let snapshot = try decoder.decode(
+            ContextSnapshot.self, from: json.data(using: .utf8)!  // swiftlint:disable:this force_unwrapping
+        )
+        #expect(snapshot.pct == 42.5)
+    }
+
+    @Test("AgentSession decodes with context_snapshots")
+    func sessionWithSnapshots() throws {
+        let json = """
+            {
+                "session_id": "s1",
+                "cwd": "/tmp",
+                "project_name": "test",
+                "status": "working",
+                "is_hook_tracked": true,
+                "context_snapshots": [
+                    {"t": "2026-03-22T10:00:00Z", "pct": 10.0},
+                    {"t": "2026-03-22T10:05:00Z", "pct": 25.3}
+                ]
+            }
+            """
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let session = try decoder.decode(
+            AgentSession.self, from: json.data(using: .utf8)!  // swiftlint:disable:this force_unwrapping
+        )
+        #expect(session.contextSnapshots?.count == 2)
+        #expect(session.contextSnapshots?.last?.pct == 25.3)
+    }
+
+    @Test("AgentSession decodes without context_snapshots (backward compat)")
+    func sessionWithoutSnapshots() throws {
+        let json = """
+            {
+                "session_id": "s2",
+                "cwd": "/tmp",
+                "project_name": "test",
+                "status": "working",
+                "is_hook_tracked": false
+            }
+            """
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let session = try decoder.decode(
+            AgentSession.self, from: json.data(using: .utf8)!  // swiftlint:disable:this force_unwrapping
+        )
+        #expect(session.contextSnapshots == nil)
+    }
 }

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -130,6 +130,29 @@ Horizontal progress bar showing context window usage.
 
 ---
 
+### SparklineView
+**File**: `Sources/ClawdboardLib/Views/Components.swift`
+
+Miniature line chart showing context usage over time per session.
+
+| Property | Value |
+|----------|-------|
+| Collapsed size | 80 x 16pt |
+| Expanded size | 120 x 20pt |
+| Stroke width | 1pt |
+| Fill opacity | 15% under line |
+| Min data points | 2 snapshots to render |
+| Max snapshots | 100 (capped in hook) |
+| Renderer | SwiftUI `Canvas` |
+
+**Stroke color**: Uses the shared usage gauge color scale based on latest value (see Color System).
+
+**Collapsed placement**: Trailing edge of session row, between content and chevron, paired with context % text. Only shown for hook-tracked sessions with 2+ snapshots.
+
+**Expanded placement**: Inline with ContextBar in the details section, providing trend alongside current state.
+
+---
+
 ### UsageWindowView (Progress Bar)
 **File**: `Sources/ClawdboardLib/Views/Components.swift`
 


### PR DESCRIPTION
## Summary

- Add a 30-minute rolling activity sparkline to each session row showing context consumption rate over time (CPU-monitor style)
- Red dots on the sparkline mark when approval was requested
- Sparkline appears in both collapsed (80x16pt) and expanded (120x20pt) views
- Fix chevron expand/collapse tap target that was being swallowed by parent gesture
- Remove idle time text ("18h ago") from collapsed rows

Closes #18

## Test plan

- [x] `mise run build` passes
- [x] `mise run test` — all 22 tests pass (3 new for ContextSnapshot/AgentSession decoding)
- [x] `mise run format` — no changes
- [ ] Manual: verify sparkline renders activity for active sessions
- [ ] Manual: verify red dots appear on approval events
- [ ] Manual: verify chevron expand/collapse works
- [ ] Manual: verify sparkline width is consistent across rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)