### PR TITLE
feat: PR status icons, status label polish, sparkline improvements

### DIFF
--- a/Sources/ClawdboardLib/AppState.swift
+++ b/Sources/ClawdboardLib/AppState.swift
@@ -63,6 +63,9 @@ public class AppState {
     // MARK: - Lifecycle
 
     public func start() {
+        startDiffStatsProvider()
+        startPRStatusProvider()
+
         stateWatcher = SessionStateWatcher { [weak self] hookSessions in
             self?.localSessions = hookSessions
             self?.rebuildSessions()
@@ -71,8 +74,6 @@ public class AppState {
 
         startRemoteWatcher()
         startUsageLimitsWatcher()
-        startDiffStatsProvider()
-        startPRStatusProvider()
     }
 
     public func stop() {
@@ -231,9 +232,9 @@ public class AppState {
     private func mergePRStatus() {
         guard let provider = prStatusProvider else { return }
         for i in sessions.indices {
-            if let status = provider.prStatusCache[sessions[i].sessionId] {
-                if sessions[i].prStatus != status {
-                    sessions[i].prStatus = status
+            if let info = provider.prInfoCache[sessions[i].sessionId] {
+                if sessions[i].prInfo != info {
+                    sessions[i].prInfo = info
                 }
             }
         }
@@ -351,12 +352,17 @@ public class AppState {
             }
         }
 
-        // Preserve PR status from previous cycle.
+        // Preserve PR info from previous cycle or disk cache.
         if let provider = prStatusProvider {
-            let cache = provider.prStatusCache
+            let sessionCache = provider.prInfoCache
             for i in all.indices {
-                if let status = cache[all[i].sessionId] {
-                    all[i].prStatus = status
+                if let info = sessionCache[all[i].sessionId] {
+                    all[i].prInfo = info
+                } else if let repo = all[i].githubRepo,
+                    let branch = all[i].gitBranch,
+                    let info = provider.cachedInfo(repo: repo, branch: branch)
+                {
+                    all[i].prInfo = info
                 }
             }
         }

--- a/Sources/ClawdboardLib/Models.swift
+++ b/Sources/ClawdboardLib/Models.swift
@@ -172,10 +172,10 @@ public enum AgentStatus: String, Codable, CaseIterable {
         switch self {
         case .working: return "Working"
         case .pendingWaiting: return "Working"  // Show as working until debounce completes
-        case .needsApproval: return "Approval"
+        case .needsApproval: return "Approve"
         case .waiting: return "Your turn"
         case .unknown: return "Unknown"
-        case .abandoned: return "Idle"
+        case .abandoned: return "Inactive"
         }
     }
 }
@@ -213,6 +213,17 @@ public enum PRStatus: String, Codable, Equatable {
     case open
     case merged
     case closed
+}
+
+/// PR status paired with the actual PR URL.
+public struct PRInfo: Codable, Equatable {
+    public let status: PRStatus
+    public let url: String?
+
+    public init(status: PRStatus, url: String? = nil) {
+        self.status = status
+        self.url = url
+    }
 }
 
 // MARK: - Agent Session
@@ -271,7 +282,7 @@ public struct AgentSession: Identifiable, Codable, Equatable {
     public var approvalTimestamps: [Date]?
 
     /// PR status for this session's branch (fetched Swift-side via `gh` CLI, not persisted)
-    public var prStatus: PRStatus?
+    public var prInfo: PRInfo?
 
     enum CodingKeys: String, CodingKey {
         case sessionId = "session_id"
@@ -296,7 +307,7 @@ public struct AgentSession: Identifiable, Codable, Equatable {
         case deletions
         case contextSnapshots = "context_snapshots"
         case approvalTimestamps = "approval_timestamps"
-        case prStatus = "pr_status"
+        case prInfo = "pr_info"
     }
 
     public init(
@@ -322,7 +333,7 @@ public struct AgentSession: Identifiable, Codable, Equatable {
         deletions: Int? = nil,
         contextSnapshots: [ContextSnapshot]? = nil,
         approvalTimestamps: [Date]? = nil,
-        prStatus: PRStatus? = nil
+        prInfo: PRInfo? = nil
     ) {
         self.sessionId = sessionId
         self.cwd = cwd
@@ -346,7 +357,7 @@ public struct AgentSession: Identifiable, Codable, Equatable {
         self.deletions = deletions
         self.contextSnapshots = contextSnapshots
         self.approvalTimestamps = approvalTimestamps
-        self.prStatus = prStatus
+        self.prInfo = prInfo
     }
 
     /// Display title: AI-generated slug title, or a placeholder while generating

--- a/Sources/ClawdboardLib/PRStatusProvider.swift
+++ b/Sources/ClawdboardLib/PRStatusProvider.swift
@@ -39,16 +39,22 @@ public class PRStatusProvider {
 
     // MARK: - Cache (persisted to disk)
 
-    /// Cached PR status keyed by `repo:branch`. Access only from `queue`.
-    private var _diskCache: [String: PRStatus] = [:]
+    /// Cached PR info keyed by `repo:branch`. Access only from `queue`.
+    private var _diskCache: [String: PRInfo] = [:]
 
-    /// Resolved PR status keyed by session ID (derived from _diskCache + targets).
+    /// Resolved PR info keyed by session ID (derived from _diskCache + targets).
     /// Access only from `queue`.
-    private var _sessionCache: [String: PRStatus] = [:]
+    private var _sessionCache: [String: PRInfo] = [:]
 
-    /// Thread-safe snapshot of PR status cache keyed by session ID.
-    public var prStatusCache: [String: PRStatus] {
+    /// Thread-safe snapshot of PR info cache keyed by session ID.
+    public var prInfoCache: [String: PRInfo] {
         queue.sync { _sessionCache }
+    }
+
+    /// Look up PR info from disk cache by repo:branch (bypasses session mapping).
+    /// Useful for immediate cache hits before `updateTargets` has run.
+    public func cachedInfo(repo: String, branch: String) -> PRInfo? {
+        queue.sync { _diskCache["\(repo):\(branch)"] }
     }
 
     // MARK: - Session tracking
@@ -97,7 +103,7 @@ public class PRStatusProvider {
     /// Load disk cache. Must be called from `queue`.
     private func loadCache() {
         guard let data = try? Data(contentsOf: Self.cacheFile),
-            let dict = try? JSONDecoder().decode([String: PRStatus].self, from: data)
+            let dict = try? JSONDecoder().decode([String: PRInfo].self, from: data)
         else { return }
         _diskCache = dict
     }
@@ -108,13 +114,13 @@ public class PRStatusProvider {
         try? data.write(to: Self.cacheFile, options: .atomic)
     }
 
-    /// Rebuild session ID → PRStatus mapping from disk cache + current targets.
+    /// Rebuild session ID → PRInfo mapping from disk cache + current targets.
     /// Must be called from `queue`.
     private func rebuildSessionCache() {
-        var sessionCache: [String: PRStatus] = [:]
+        var sessionCache: [String: PRInfo] = [:]
         for target in targets {
-            if let status = _diskCache[target.cacheKey] {
-                sessionCache[target.sessionId] = status
+            if let info = _diskCache[target.cacheKey] {
+                sessionCache[target.sessionId] = info
             }
         }
         _sessionCache = sessionCache
@@ -145,13 +151,13 @@ public class PRStatusProvider {
                 continue
             }
 
-            guard let status = fetchPRStatus(repo: target.githubRepo, branch: target.gitBranch)
+            guard let info = fetchPRInfo(repo: target.githubRepo, branch: target.gitBranch)
             else { continue }
 
             lastFetch[key] = now
 
-            if _diskCache[key] != status {
-                _diskCache[key] = status
+            if _diskCache[key] != info {
+                _diskCache[key] = info
                 anyChanged = true
             }
         }
@@ -192,8 +198,8 @@ public class PRStatusProvider {
         return path
     }
 
-    /// Run `gh pr list --head <branch> --repo <repo> --json state --limit 1`.
-    private func fetchPRStatus(repo: String, branch: String) -> PRStatus? {
+    /// Run `gh pr list --head <branch> --repo <repo> --json state,url --limit 1`.
+    private func fetchPRInfo(repo: String, branch: String) -> PRInfo? {
         guard let gh = resolveGhPath() else { return nil }
 
         let process = Process()
@@ -202,7 +208,7 @@ public class PRStatusProvider {
             "pr", "list",
             "--head", branch,
             "--repo", repo,
-            "--json", "state",
+            "--json", "state,url",
             "--limit", "1",
             "--state", "all",
         ]
@@ -225,18 +231,20 @@ public class PRStatusProvider {
         else { return nil }
 
         guard let first = json.first, let state = first["state"] as? String else {
-            return .none
+            return PRInfo(status: .none)
         }
+
+        let prUrl = first["url"] as? String
 
         switch state {
         case "OPEN":
-            return .open
+            return PRInfo(status: .open, url: prUrl)
         case "MERGED":
-            return .merged
+            return PRInfo(status: .merged, url: prUrl)
         case "CLOSED":
-            return .closed
+            return PRInfo(status: .closed, url: prUrl)
         default:
-            return .none
+            return PRInfo(status: .none)
         }
     }
 }

--- a/Sources/ClawdboardLib/Views/AgentRow.swift
+++ b/Sources/ClawdboardLib/Views/AgentRow.swift
@@ -55,20 +55,16 @@ public struct AgentRow: View {
                                 Text("·")
                             }
                             Text(session.displayStatus.displayLabel)
+                                .frame(width: 56, alignment: .leading)
                             if session.isHookTracked {
                                 if let branch = session.gitBranch {
-                                    Text("·")
                                     if let compareUrl = session.compareUrl,
                                         let url = URL(string: compareUrl)
                                     {
                                         Link(destination: url) {
-                                            HStack(spacing: 2) {
-                                                Image(systemName: "arrow.triangle.pull")
-                                                    .font(.caption2)
-                                                Text(branch)
-                                                    .lineLimit(1)
-                                                    .truncationMode(.middle)
-                                            }
+                                            Text(branch)
+                                                .lineLimit(1)
+                                                .truncationMode(.middle)
                                         }
                                         .layoutPriority(-1)
                                         .pointingHandCursor()
@@ -79,10 +75,7 @@ public struct AgentRow: View {
                                             .layoutPriority(-1)
                                     }
                                 }
-                                if let diffStats = session.formattedDiffStats {
-                                    Text("·")
-                                    DiffStatsLabel(stats: diffStats)
-                                }
+                                // Diff stats shown in expanded details only
                             }
                             if session.activeSubagentCount > 0 {
                                 Text("·")
@@ -98,12 +91,12 @@ public struct AgentRow: View {
 
                     Spacer()
 
-                    HStack(spacing: 4) {
+                    HStack(spacing: 12) {
                         SparklineView(
                             snapshots: session.contextSnapshots ?? [],
                             approvalTimestamps: session.approvalTimestamps ?? []
                         )
-                        PRStatusIcon(prStatus: session.prStatus)
+                        PRStatusIcon(prInfo: session.prInfo)
                     }
                     .fixedSize()
                 }
@@ -195,11 +188,6 @@ public struct AgentRow: View {
                         .font(.caption)
                         .foregroundStyle(.secondary)
                         .frame(width: 60, alignment: .trailing)
-                    SparklineView(
-                        snapshots: session.contextSnapshots ?? [],
-                        approvalTimestamps: session.approvalTimestamps ?? []
-                    )
-                    .frame(width: 120, height: 20)
                     ContextBar(percentage: pct)
                     Text(session.formattedContext)
                         .font(.caption2.monospacedDigit())

--- a/Sources/ClawdboardLib/Views/Components.swift
+++ b/Sources/ClawdboardLib/Views/Components.swift
@@ -90,42 +90,322 @@ public struct ContextBar: View {
 
 // MARK: - PR Status Icon
 
-/// Displays the pull request status for a session's branch.
+/// Displays the pull request status for a session's branch using
+/// custom-drawn GitHub-style icons.
 public struct PRStatusIcon: View {
-    public let prStatus: PRStatus?
+    public let prInfo: PRInfo?
+
+    @State private var isHovered = false
+
+    private static let iconSize: CGFloat = 14
+    private static let badgeSize: CGFloat = 24
+
+    private var status: PRStatus? { prInfo?.status }
+
+    private var iconColor: Color {
+        switch status {
+        case .some(.open): return .green
+        case .some(.merged): return .purple
+        case .some(.closed): return .secondary
+        case .some(.none), nil: return .secondary
+        }
+    }
+
+    private var hasBadge: Bool {
+        switch status {
+        case .some(.open), .some(.merged), .some(.closed): return true
+        default: return false
+        }
+    }
+
+    private var prUrl: URL? {
+        prInfo?.url.flatMap { URL(string: $0) }
+    }
+
+    private var isClickable: Bool { prUrl != nil }
 
     public var body: some View {
         Group {
-            switch prStatus {
+            switch status {
             case .some(.open):
-                Image(systemName: "arrow.triangle.pull")
+                PROpenIcon()
                     .foregroundStyle(.green)
             case .some(.merged):
-                Image(systemName: "arrow.triangle.merge")
+                PRMergedIcon()
                     .foregroundStyle(.purple)
             case .some(.closed):
-                Image(systemName: "xmark.circle")
+                PRClosedIcon()
                     .foregroundStyle(.secondary)
             case .some(.none), nil:
-                Image(systemName: "circle")
-                    .foregroundStyle(.tertiary)
+                Color.clear
             }
         }
-        .font(.system(size: 12))
-        .frame(width: 16, alignment: .center)
+        .frame(width: Self.iconSize, height: Self.iconSize)
+        .frame(width: Self.badgeSize, height: Self.badgeSize)
+        .background(
+            RoundedRectangle(cornerRadius: 6)
+                .fill(hasBadge ? iconColor.opacity(isHovered ? 0.22 : 0.12) : .clear)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 6)
+                .strokeBorder(
+                    hasBadge ? iconColor.opacity(isHovered ? 0.5 : 0.3) : .clear,
+                    lineWidth: 0.5)
+        )
+        .overlay(
+            hasBadge
+                ? nil
+                : RoundedRectangle(cornerRadius: 5)
+                    .strokeBorder(style: StrokeStyle(lineWidth: 0.5, dash: [2, 2]))
+                    .foregroundStyle(.tertiary)
+                    .padding(1.5)
+        )
+        .onHover { isHovered = isClickable ? $0 : false }
+        .pointingHandCursor(enabled: isClickable)
+        .onTapGesture {
+            if let prUrl { NSWorkspace.shared.open(prUrl) }
+        }
+        .animation(.easeInOut(duration: 0.1), value: isHovered)
     }
 }
 
+// MARK: - GitHub-style PR Icon Shapes
+
+/// Phosphor Icons SVG path data (viewBox 0 0 256 256).
+private enum PhosphorPaths {
+    // swiftlint:disable line_length
+    static let gitPullRequest =
+        "M104,64A32,32,0,1,0,64,95v66a32,32,0,1,0,16,0V95A32.06,32.06,0,0,0,104,64ZM56,64A16,16,0,1,1,72,80,16,16,0,0,1,56,64ZM88,192a16,16,0,1,1-16-16A16,16,0,0,1,88,192Zm120-31V110.63a23.85,23.85,0,0,0-7-17L163.31,56H192a8,8,0,0,0,0-16H144a8,8,0,0,0-8,8V96a8,8,0,0,0,16,0V67.31L189.66,105a8,8,0,0,1,2.34,5.66V161a32,32,0,1,0,16,0Zm-8,47a16,16,0,1,1,16-16A16,16,0,0,1,200,208Z"
+    static let gitMerge =
+        "M208,112a32.05,32.05,0,0,0-30.69,23l-42.21-6a8,8,0,0,1-4.95-2.71L94.43,84.55A32,32,0,1,0,72,87v82a32,32,0,1,0,16,0V101.63l30,35a24,24,0,0,0,14.83,8.14l44,6.28A32,32,0,1,0,208,112ZM64,56A16,16,0,1,1,80,72,16,16,0,0,1,64,56ZM96,200a16,16,0,1,1-16-16A16,16,0,0,1,96,200Zm112-40a16,16,0,1,1,16-16A16,16,0,0,1,208,160Z"
+    // swiftlint:enable line_length
+}
+
+
+/// Open PR icon — Phosphor Icons git-pull-request SVG path rendered as a filled shape.
+private struct PROpenIcon: View {
+    var body: some View {
+        SVGPathShape(svgPath: PhosphorPaths.gitPullRequest, viewBox: 256)
+    }
+}
+
+/// Renders an SVG path string as a filled SwiftUI shape, scaled to fit.
+private struct SVGPathShape: View, Shape {
+    let svgPath: String
+    let viewBox: CGFloat
+
+    func path(in rect: CGRect) -> Path {
+        let scale = min(rect.width, rect.height) / viewBox
+        let cgPath = CGMutablePath()
+        parseSVGPath(svgPath, into: cgPath)
+        var transform = CGAffineTransform(scaleX: scale, y: scale)
+        guard let scaled = cgPath.copy(using: &transform) else {
+            return Path(cgPath)
+        }
+        return Path(scaled)
+    }
+}
+
+/// Parse a subset of SVG path `d` attribute into a CGMutablePath.
+/// Supports M, m, L, l, H, h, V, v, A, a, Z, z commands.
+private func parseSVGPath(_ d: String, into path: CGMutablePath) {
+    var chars = Array(d)
+    var idx = 0
+    var currentX: CGFloat = 0
+    var currentY: CGFloat = 0
+    var lastCommand: Character = " "
+
+    func skipWhitespaceAndCommas() {
+        while idx < chars.count && (chars[idx] == " " || chars[idx] == "," || chars[idx] == "\n") {
+            idx += 1
+        }
+    }
+
+    func parseNumber() -> CGFloat? {
+        skipWhitespaceAndCommas()
+        guard idx < chars.count else { return nil }
+        var numStr = ""
+        if chars[idx] == "-" || chars[idx] == "+" {
+            numStr.append(chars[idx])
+            idx += 1
+        }
+        var hasDot = false
+        while idx < chars.count {
+            let c = chars[idx]
+            if c.isNumber {
+                numStr.append(c)
+                idx += 1
+            } else if c == "." && !hasDot {
+                hasDot = true
+                numStr.append(c)
+                idx += 1
+            } else {
+                break
+            }
+        }
+        // Handle cases like "16-16" (two numbers without separator)
+        return numStr.isEmpty ? nil : CGFloat(Double(numStr) ?? 0)
+    }
+
+    func parseCoordPair() -> CGPoint? {
+        guard let x = parseNumber(), let y = parseNumber() else { return nil }
+        return CGPoint(x: x, y: y)
+    }
+
+    while idx < chars.count {
+        skipWhitespaceAndCommas()
+        guard idx < chars.count else { break }
+
+        var cmd = chars[idx]
+        if cmd.isLetter {
+            idx += 1
+            lastCommand = cmd
+        } else {
+            // Implicit repeat of last command
+            cmd = lastCommand
+        }
+
+        switch cmd {
+        case "M":
+            guard let pt = parseCoordPair() else { break }
+            path.move(to: pt)
+            currentX = pt.x
+            currentY = pt.y
+            lastCommand = "L"  // subsequent coords are lineTo
+        case "m":
+            guard let pt = parseCoordPair() else { break }
+            currentX += pt.x
+            currentY += pt.y
+            path.move(to: CGPoint(x: currentX, y: currentY))
+            lastCommand = "l"
+        case "L":
+            guard let pt = parseCoordPair() else { break }
+            path.addLine(to: pt)
+            currentX = pt.x
+            currentY = pt.y
+        case "l":
+            guard let pt = parseCoordPair() else { break }
+            currentX += pt.x
+            currentY += pt.y
+            path.addLine(to: CGPoint(x: currentX, y: currentY))
+        case "H":
+            guard let x = parseNumber() else { break }
+            path.addLine(to: CGPoint(x: x, y: currentY))
+            currentX = x
+        case "h":
+            guard let dx = parseNumber() else { break }
+            currentX += dx
+            path.addLine(to: CGPoint(x: currentX, y: currentY))
+        case "V":
+            guard let y = parseNumber() else { break }
+            path.addLine(to: CGPoint(x: currentX, y: y))
+            currentY = y
+        case "v":
+            guard let dy = parseNumber() else { break }
+            currentY += dy
+            path.addLine(to: CGPoint(x: currentX, y: currentY))
+        case "A", "a":
+            let relative = cmd == "a"
+            guard let rx = parseNumber(),
+                let ry = parseNumber(),
+                let _ = parseNumber(),  // x-axis rotation (unused for circles)
+                let largeArc = parseNumber(),
+                let sweep = parseNumber(),
+                let ex = parseNumber(),
+                let ey = parseNumber()
+            else { break }
+
+            let endX = relative ? currentX + ex : ex
+            let endY = relative ? currentY + ey : ey
+
+            // Convert SVG arc to center parameterization for addArc
+            addSVGArc(
+                to: path, from: CGPoint(x: currentX, y: currentY),
+                to: CGPoint(x: endX, y: endY),
+                rx: rx, ry: ry,
+                largeArc: largeArc != 0, sweep: sweep != 0)
+
+            currentX = endX
+            currentY = endY
+        case "Z", "z":
+            path.closeSubpath()
+        default:
+            idx += 1  // skip unknown
+        }
+    }
+}
+
+/// Convert SVG arc parameters to CGPath arc.
+private func addSVGArc(
+    to path: CGMutablePath,
+    from start: CGPoint, to end: CGPoint,
+    rx: CGFloat, ry: CGFloat,
+    largeArc: Bool, sweep: Bool
+) {
+    // For equal rx/ry (circles), use the standard center-arc conversion
+    let r = max(rx, ry)
+    guard r > 0 else {
+        path.addLine(to: end)
+        return
+    }
+
+    let dx = (start.x - end.x) / 2
+    let dy = (start.y - end.y) / 2
+    let d2 = dx * dx + dy * dy
+    let r2 = r * r
+
+    // Clamp radius if needed
+    let actualR = d2 > r2 ? sqrt(d2) : r
+
+    let sr2 = actualR * actualR
+    let sq = max(0, (sr2 - d2) / d2)
+    let sign: CGFloat = (largeArc == sweep) ? -1 : 1
+    let factor = sign * sqrt(sq)
+
+    let cx = (start.x + end.x) / 2 + factor * dy
+    let cy = (start.y + end.y) / 2 - factor * dx
+
+    let startAngle = atan2(start.y - cy, start.x - cx)
+    let endAngle = atan2(end.y - cy, end.x - cx)
+
+    // SVG sweep=1 means clockwise, but CGPath clockwise param is inverted (flipped Y)
+    path.addArc(
+        center: CGPoint(x: cx, y: cy), radius: actualR,
+        startAngle: startAngle, endAngle: endAngle,
+        clockwise: !sweep)
+}
+
+/// Merged PR icon — Phosphor Icons git-merge SVG path rendered as a filled shape.
+private struct PRMergedIcon: View {
+    var body: some View {
+        SVGPathShape(svgPath: PhosphorPaths.gitMerge, viewBox: 256)
+    }
+}
+
+/// Closed PR icon: reuses the open PR shape (same visual structure).
+private struct PRClosedIcon: View {
+    var body: some View {
+        SVGPathShape(svgPath: PhosphorPaths.gitPullRequest, viewBox: 256)
+    }
+}
+
+// DashedCircleIcon removed — "no PR" state now uses a dashed rounded rectangle overlay
+
 // MARK: - Sparkline View
 
-/// Miniature activity chart showing context usage rate over a 30-minute window.
+/// Miniature activity chart showing context usage rate over a 2-hour window.
 /// Plots context_pct deltas per minute bucket — peaks = active generation, flat = idle.
 public struct SparklineView: View {
     public let snapshots: [ContextSnapshot]
     public var approvalTimestamps: [Date] = []
 
-    private static let windowMinutes = 30
-    private static let bucketCount = 30  // one bucket per minute
+    private static let windowMinutes = 120
+    private static let bucketCount = 60  // one bucket per 2 minutes
+    private static let redrawInterval: TimeInterval = 30
+
+    /// Periodic tick to force redraw so the time window slides even when no new data arrives.
+    @State private var tick = false
+    private let timer = Timer.publish(every: redrawInterval, on: .main, in: .common).autoconnect()
 
     public init(snapshots: [ContextSnapshot], approvalTimestamps: [Date] = []) {
         self.snapshots = snapshots
@@ -133,6 +413,8 @@ public struct SparklineView: View {
     }
 
     public var body: some View {
+        // tick is read here so SwiftUI tracks it as a dependency
+        let _ = tick
         Canvas { context, size in
             let windowStart = Date().addingTimeInterval(
                 -Double(Self.windowMinutes * 60))
@@ -188,10 +470,11 @@ public struct SparklineView: View {
                 context.fill(Path(ellipseIn: dot), with: .color(.red))
             }
         }
-        .frame(width: 80, height: 16)
+        .frame(width: 130, height: 24)
+        .onReceive(timer) { _ in tick.toggle() }
     }
 
-    /// Compute activity (context_pct delta) per minute bucket over the last 30 minutes.
+    /// Compute activity (context_pct delta) per 2-minute bucket over the last 2 hours.
     private var activityBuckets: [Double] {
         guard snapshots.count >= 2 else { return [] }
 
@@ -200,7 +483,7 @@ public struct SparklineView: View {
             -Double(Self.windowMinutes * 60))
         let bucketDuration = Double(Self.windowMinutes * 60) / Double(Self.bucketCount)
 
-        // Filter to last 30 minutes
+        // Filter to last 2 hours
         let recent = snapshots.filter { $0.t >= windowStart }
         guard recent.count >= 2 else { return [] }
 
@@ -369,7 +652,7 @@ struct PointingHandCursor: NSViewRepresentable {
 
 extension View {
     /// Adds a pointing-hand cursor when hovering over this view, using AppKit cursor rects.
-    func pointingHandCursor() -> some View {
-        overlay(PointingHandCursor())
+    func pointingHandCursor(enabled: Bool = true) -> some View {
+        overlay(enabled ? PointingHandCursor() : nil)
     }
 }

--- a/Sources/ClawdboardLib/Views/PanelView.swift
+++ b/Sources/ClawdboardLib/Views/PanelView.swift
@@ -79,7 +79,7 @@ public struct PanelView: View {
             // Status pills — compact: dot + count only
             HStack(spacing: 6) {
                 if appState.needsApprovalCount > 0 {
-                    StatusPill(count: appState.needsApprovalCount, label: "approval", color: .red)
+                    StatusPill(count: appState.needsApprovalCount, label: "approve", color: .red)
                 }
                 if appState.waitingCount > 0 {
                     StatusPill(count: appState.waitingCount, label: "your turn", color: .green)

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -21,12 +21,12 @@ All colors are semantic SwiftUI values — they adapt automatically to light/dar
 | Status | Color | Used in |
 |--------|-------|---------|
 | Working / Pending | `.blue` | StatusDot, StatusPill, subagent dots |
-| Approval | `.red` | StatusDot, StatusPill, menu bar dot |
+| Approve | `.red` | StatusDot, StatusPill, menu bar dot |
 | Your turn (waiting) | `.green` | StatusDot, StatusPill, menu bar dot |
-| Idle (abandoned) | `.gray` at 40% opacity | StatusDot |
+| Inactive (abandoned) | `.gray` at 40% opacity | StatusDot |
 | Unknown | `.gray` | StatusDot |
 
-> **Accessibility**: Red and green are indistinguishable for ~8% of men with color vision deficiency. The critical approval/"your turn" distinction does not rely on color alone — approval is the only pulsing state, and the text label in the metadata line provides a third signal. Do not add pulsing to other states without providing an alternative non-color differentiator.
+> **Accessibility**: Red and green are indistinguishable for ~8% of men with color vision deficiency. The critical approve/"your turn" distinction does not rely on color alone — approve is the only pulsing state, and the text label in the metadata line provides a third signal. Do not add pulsing to other states without providing an alternative non-color differentiator.
 
 ### Usage Gauge Colors
 
@@ -74,7 +74,7 @@ The menu bar icon adapts based on session state:
 | Dot size | 8pt diameter |
 | Dot spacing | 4pt between dots |
 | Max dots | 8 (capped) |
-| Dot colors | `.systemRed` (approval), `.systemGreen` (your turn) |
+| Dot colors | `.systemRed` (approve), `.systemGreen` (your turn) |
 | Template mode | `false` when dots shown (preserves color) |
 | Usage ring | 14pt diameter, 2.5pt stroke, appended after dots if above threshold |
 
@@ -108,7 +108,7 @@ Header summary badges showing counts by status.
 | Pill-to-pill spacing | 6pt |
 | Padding | 6pt horizontal, 2pt vertical |
 | Text font | `.caption2` |
-| Labels | "N approval" (red), "N your turn" (green), "N working" (blue) |
+| Labels | "N approve" (red), "N your turn" (green), "N working" (blue) |
 
 Only shown when count > 0 for that status.
 
@@ -137,7 +137,7 @@ Miniature line chart showing context usage over time per session.
 
 | Property | Value |
 |----------|-------|
-| Collapsed size | 80 x 16pt |
+| Collapsed size | 130 x 24pt |
 | Expanded size | 120 x 20pt |
 | Stroke width | 1pt |
 | Fill opacity | 15% under line |
@@ -156,22 +156,25 @@ Miniature line chart showing context usage over time per session.
 ### PRStatusIcon
 **File**: `Sources/ClawdboardLib/Views/Components.swift`
 
-Displays the pull request status for a session's branch. Fetched via `gh` CLI on the Swift side (`PRStatusProvider`), not from hooks.
+Displays the pull request status for a session's branch using custom-drawn GitHub-style icons (SwiftUI Canvas). Fetched via `gh` CLI on the Swift side (`PRStatusProvider`), not from hooks.
 
 | Property | Value |
 |----------|-------|
-| Font | `.system(size: 12)` |
-| Frame width | 16pt, center-aligned |
+| Icon size | 14 x 14pt |
+| Badge size | 24 x 24pt |
+| Badge corner radius | 6pt |
+| Badge background | Icon color at 12% opacity (22% on hover) |
+| Badge border | Icon color at 30% opacity (50% on hover), 0.5pt |
 
 **States**:
-| Status | SF Symbol | Color |
-|--------|-----------|-------|
-| No PR / unknown | `circle` | `.tertiary` |
-| PR open | `arrow.triangle.pull` | `.green` |
-| PR merged | `arrow.triangle.merge` | `.purple` |
-| PR closed | `xmark.circle` | `.secondary` |
+| Status | Icon | Color | Click action |
+|--------|------|-------|------|
+| No PR / unknown | Dashed rounded rectangle outline (no icon) | `.tertiary` | None |
+| PR open | `PROpenIcon` — Phosphor git-pull-request | `.green` | Opens PR URL |
+| PR merged | `PRMergedIcon` — Phosphor git-merge | `.purple` | Opens PR URL |
+| PR closed | `PRClosedIcon` — Phosphor git-pull-request | `.secondary` | Opens PR URL |
 
-**Placement**: Trailing edge of collapsed session row, after sparkline. Always shown (empty circle when no PR data available).
+**Placement**: Trailing edge of collapsed session row, after sparkline. Always shown (dashed rectangle when no PR data available).
 
 **Data source**: `PRStatusProvider` polls `gh pr list` with 30s per-session debounce. Requires `gh` CLI to be installed and authenticated. Cache persisted to `~/.clawdboard/pr-status-cache.json` for instant display on app launch.
 
@@ -225,15 +228,15 @@ Single session row. Full row is the primary click target (Fitts's Law).
 
 **Title**: `.system(.body, weight: .medium)`. Single line, truncated. Shows AI-generated kebab-case slug title (e.g. `api-refactor`, `auth-module`, `docs-update`) when available, otherwise a placeholder slug like `new-session` (stable per session ID).
 
-**Metadata line**: `.caption`, `.secondary`, dot-separated. Order: remote host icon + name, status label (first), model, branch (with PR icon), diff stats, idle time, subagent count. All items use `.secondary` — the StatusDot already communicates state via color.
+**Metadata line**: `.caption`, `.secondary`, dot-separated. Order: remote host icon + name, status label (first), model, branch, idle time, subagent count. All items use `.secondary` — the StatusDot already communicates state via color.
 
-**Branch + PR icon** (inline in metadata):
-- SF Symbol: `arrow.triangle.pull`, `.caption2`
+**Branch** (inline in metadata):
+- Plain text (no icon — PR status is shown via trailing PRStatusIcon)
 - If `githubRepo` set: tapping opens `https://github.com/<repo>/compare/<branch>?expand=1` (GitHub redirects to existing PR or shows "Open a pull request" page)
-- If no git repo: icon and branch hidden entirely
+- If no git repo: branch hidden entirely
 - Pointing hand cursor on hover
 
-**Diff stats** (inline in metadata, after branch):
+**Diff stats** (expanded details only):
 - Format: `+N −N` with `.caption.monospacedDigit()`
 - Additions colored `.green`, deletions colored `.red`
 - Hidden when no diff data or both zero
@@ -454,11 +457,11 @@ Reactive diff stats collector. Triggered by session changes (no timer/polling) w
 
 Sessions are sorted by urgency (most attention-needed first):
 
-1. **Approval** (sort order 0)
+1. **Approve** (sort order 0)
 2. **Your turn** (sort order 1)
 3. **Pending/Working** (sort order 2–3)
 4. **Unknown** (sort order 4)
-5. **Idle/Abandoned** (sort order 5)
+5. **Inactive/Abandoned** (sort order 5)
 
 Within each status group, sessions are grouped alphabetically by GitHub repo slug (or project name for local repos), displayed as uppercase section headers.
 


### PR DESCRIPTION
## Summary
- **PR status icons**: Custom Phosphor icon badges with colored background/border, hover effect, click opens actual PR URL. Dashed rounded rect for "no PR" state.
- **PRInfo struct**: Fetches and caches both PR status and URL via `gh pr list --json state,url`. Disk cache persists across restarts.
- **Startup cache fix**: Init PR provider before state watcher so icons show immediately on launch (no flash of dashed rects).
- **Status labels**: Approval → Approve, Idle → Inactive, kept Your turn. Fixed-width label so branch name doesn't shift.
- **Sparkline**: 2h window (was 30min), 130x24pt (was 80x16), 30s auto-redraw timer for smooth sliding window. Removed from expanded details.
- **Layout**: Removed dot separator before branch name, adjusted spacing around PR icon and sparkline.

## Test plan
- [ ] Build succeeds (`mise run build`)
- [ ] All tests pass (`mise run test`)
- [ ] PR icons show correct state (green open, purple merged, gray closed, dashed rect for no PR)
- [ ] Clicking PR icon opens the PR page (not compare)
- [ ] PR icons load from cache on restart (no flash)
- [ ] Status labels show "Approve", "Your turn", "Inactive", "Working"
- [ ] Sparkline slides smoothly even when session is idle (30s redraw)
- [ ] Branch name stays aligned regardless of status label length

🤖 Generated with [Claude Code](https://claude.com/claude-code)